### PR TITLE
fix: Fixes mirror-blocked error

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -23,14 +23,14 @@
   <scm>
     <connection>scm:git:git@github.com:nativelibs4java/JNAerator.git</connection>
     <developerConnection>scm:git:git@github.com:nativelibs4java/JNAerator.git</developerConnection>
-    <url>http://github.com/nativelibs4java/JNAerator</url>
+    <url>https://github.com/nativelibs4java/JNAerator</url>
   </scm>
 
   <repositories>
     <repository>
       <id>sonatype</id>
       <name>Sonatype OSS Snapshots Repository</name>
-      <url>http://oss.sonatype.org/content/groups/public</url>
+      <url>https://oss.sonatype.org/content/groups/public</url>
     </repository>
   </repositories>
 
@@ -38,7 +38,7 @@
     <pluginRepository>
       <id>sonatype</id>
       <name>Sonatype OSS Snapshots Repository</name>
-      <url>http://oss.sonatype.org/content/groups/public</url>
+      <url>https://oss.sonatype.org/content/groups/public</url>
     </pluginRepository>
   </pluginRepositories>
   


### PR DESCRIPTION
When running `mvn clean install -X` I was getting this error `Blocked mirror for repositories`. According to this you need https for the repo urls: https://stackoverflow.com/questions/67833372/getting-blocked-mirror-for-repositories-maven-error-even-after-adding-mirrors

Changing to https fixed it for me. I can't easily repro this as it seems the settings are already adopted in mvn somewhere. But happy to provide repro instructions if needed.

Either way I think you want your code repo connections to be encrypted for security reasons.
